### PR TITLE
fix: Fix typo in frontend plugin readme

### DIFF
--- a/plugins/aws-codeservices/README.md
+++ b/plugins/aws-codeservices/README.md
@@ -1,4 +1,4 @@
-# AWS Code Services backend plugin for Backstage
+# AWS Code Services frontend plugin for Backstage
 
 This frontend UI plugin for Backstage adds functionality to interact with AWS Code Services services such as [AWS CodePipeline](https://aws.amazon.com/codepipeline/), [AWS CodeBuild](https://aws.amazon.com/codebuild/) and [AWS CodeDeploy](https://aws.amazon.com/codedeploy/).
 


### PR DESCRIPTION
*Description of changes:* Fixed typo in frontend plugins readme, saying it was the backend plugin.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
